### PR TITLE
sync: changes after #1681

### DIFF
--- a/emacs/erlang.el
+++ b/emacs/erlang.el
@@ -4,7 +4,7 @@
 ;; Author:   Anders Lindgren
 ;; Keywords: erlang, languages, processes
 ;; Date:     2011-12-11
-;; Version:  2.8.0
+;; Version:  2.8.1
 ;; Package-Requires: ((emacs "24.1"))
 
 ;; %CopyrightBegin%
@@ -84,7 +84,7 @@
   "The Erlang programming language."
   :group 'languages)
 
-(defconst erlang-version "2.8.0"
+(defconst erlang-version "2.8.1"
   "The version number of Erlang mode.")
 
 (defcustom erlang-root-dir nil
@@ -2742,7 +2742,7 @@ Return nil if inside string, t if in a comment."
                   (1+ (nth 2 stack-top)))
                  ((= (char-syntax (following-char)) ?\))
                   (goto-char (nth 1 stack-top))
-                  (cond ((looking-at "[({]\\s *\\($\\|%\\)")
+                  (cond ((erlang-record-or-function-args-p)
                          ;; Line ends with parenthesis.
                          (let ((previous (erlang-indent-find-preceding-expr))
                                (stack-pos (nth 2 stack-top)))
@@ -2752,19 +2752,10 @@ Return nil if inside string, t if in a comment."
                          (nth 2 stack-top))))
                  ((= (following-char) ?,)
                   ;; a comma at the start of the line: line up with opening parenthesis.
-                  (nth 2 stack-top))
+                  (min (nth 2 stack-top)
+                       (erlang-indent-element stack-top indent-point token)))
                  (t
-                  (goto-char (nth 1 stack-top))
-                  (let ((base (cond ((looking-at "[({]\\s *\\($\\|%\\)")
-                                     ;; Line ends with parenthesis.
-                                     (erlang-indent-parenthesis (nth 2 stack-top)))
-                                    (t
-                                     ;; Indent to the same column as the first
-                                     ;; argument.
-                                     (goto-char (1+ (nth 1 stack-top)))
-                                     (skip-chars-forward " \t")
-                                     (current-column)))))
-                    (erlang-indent-standard indent-point token base 't)))))
+                  (erlang-indent-element stack-top indent-point token))))
           ;;
           ((eq (car stack-top) '<<)
            ;; Element of binary (possible comprehension) expression,
@@ -2773,13 +2764,11 @@ Return nil if inside string, t if in a comment."
                   (+ 2 (nth 2 stack-top)))
                  ((looking-at "\\(>>\\)[^_a-zA-Z0-9]")
                   (nth 2 stack-top))
+                 ((= (following-char) ?,)
+                  (min (+ (nth 2 stack-top) 1)
+                       (- (erlang-indent-to-first-element stack-top 2) 1)))
                  (t
-                  (goto-char (nth 1 stack-top))
-                  ;; Indent to the same column as the first
-                  ;; argument.
-                  (goto-char (+ 2 (nth 1 stack-top)))
-                  (skip-chars-forward " \t")
-                  (current-column))))
+                  (erlang-indent-to-first-element stack-top 2))))
 
           ((memq (car stack-top) '(icr fun spec))
            ;; The default indentation is the column of the option
@@ -2835,12 +2824,13 @@ Return nil if inside string, t if in a comment."
                (let ((base (erlang-indent-find-base stack indent-point off skip)))
                  ;; Special cases
                  (goto-char indent-point)
-                 (cond ((looking-at "\\(end\\|after\\)\\($\\|[^_a-zA-Z0-9]\\)")
+                 (cond ((looking-at "\\(;\\|end\\|after\\)\\($\\|[^_a-zA-Z0-9]\\)")
                         (if (eq (car stack-top) '->)
                             (erlang-pop stack))
-                        (if stack
-                            (erlang-caddr (car stack))
-                          0))
+                        (cond ((and stack (looking-at ";"))
+                               (+ (erlang-caddr (car stack)) (- erlang-indent-level 2)))
+                              (stack (erlang-caddr (car stack)))
+                              (t off)))
                        ((looking-at "catch\\b\\($\\|[^_a-zA-Z0-9]\\)")
                         ;; Are we in a try
                         (let ((start (if (eq (car stack-top) '->)
@@ -2914,6 +2904,22 @@ Return nil if inside string, t if in a comment."
                                 (current-column))) start-alternativ))))))
           )))
 
+(defun erlang-indent-to-first-element (stack-top extra)
+  ;; Indent to the same column as the first
+  ;; argument.  extra should be 1 for lists tuples or 2 for binaries
+  (goto-char (+ (nth 1 stack-top) extra))
+  (skip-chars-forward " \t")
+  (current-column))
+
+(defun erlang-indent-element (stack-top indent-point token)
+  (goto-char (nth 1 stack-top))
+  (let ((base (cond ((erlang-record-or-function-args-p)
+                     ;; Line ends with parenthesis.
+                     (erlang-indent-parenthesis (nth 2 stack-top)))
+                    (t
+                     (erlang-indent-to-first-element stack-top 1)))))
+    (erlang-indent-standard indent-point token base 't)))
+
 (defun erlang-indent-standard (indent-point token base inside-parenthesis)
   "Standard indent when in blocks or tuple or arguments.
    Look at last thing to see in what state we are, move relative to the base."
@@ -2939,6 +2945,9 @@ Return nil if inside string, t if in a comment."
                ;; Avoid treating comments a continued line.
                ((= (following-char) ?%)
                 base)
+               ((and (= (following-char) ?,) inside-parenthesis)
+                ;; a comma at the start of the line line up with parenthesis
+                (- base 1))
                ;; Continued line (e.g. line beginning
                ;; with an operator.)
                (t
@@ -3028,11 +3037,21 @@ This assumes that the preceding expression is either simple
                (t col)))
        col))))
 
+(defun erlang-record-or-function-args-p ()
+  (and (looking-at "[({]\\s *\\($\\|%\\)")
+       (or (eq (following-char) ?\( )
+           (save-excursion
+             (ignore-errors (forward-sexp (- 1)))
+             (eq (preceding-char) ?#)))))
+
 (defun erlang-indent-parenthesis (stack-position)
   (let ((previous (erlang-indent-find-preceding-expr)))
-    (if (> previous stack-position)
-        (+ stack-position erlang-argument-indent)
-      (+ previous erlang-argument-indent))))
+    (cond ((eq previous stack-position) ;; tuple or map not a record
+           (1+ stack-position))
+          ((> previous stack-position)
+           (+ stack-position erlang-argument-indent))
+          (t
+           (+ previous erlang-argument-indent)))))
 
 (defun erlang-skip-blank (&optional lim)
   "Skip over whitespace and comments until limit reached."

--- a/test/after/tabs.erl
+++ b/test/after/tabs.erl
@@ -19,6 +19,27 @@
 
 %% API
 
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+
+-spec release(kz_term:ne_binaries()) -> ret().
+release(Nums) ->
+    release(Nums, knm_number_options:default()).
+
+-spec release(kz_term:ne_binaries(), knm_number_options:options()) -> ret().
+release(Nums, Options) ->
+    ret(pipe(do_get_pn(Nums, Options)
+            ,[fun try_release/1
+             ,fun knm_number:new/1
+             ,fun knm_providers:delete/1
+             ,fun unwind_maybe_disconnect/1
+             ,fun save_phone_numbers/1
+             ])).
+
+
+
 t(ABS) -> erlang:abs(
             ABS
            ).

--- a/test/after/tabs.erl
+++ b/test/after/tabs.erl
@@ -47,11 +47,11 @@ t(ABS) -> erlang:abs(
 a () ->
     amqp:callect(
       dst
-                ,meta
-                ,[{<<"blip">>, <<"bloop">>}
-                 ,{<<"blop">>, 1}
-                 ,{<<"blup">>, 42}
-                 ]
+     ,meta
+     ,[{<<"blip">>, <<"bloop">>}
+      ,{<<"blop">>, 1}
+      ,{<<"blup">>, 42}
+      ]
      ).
 
 b(Arg) ->

--- a/test/after/teletype_new_account.erl
+++ b/test/after/teletype_new_account.erl
@@ -5,14 +5,14 @@
 
 -define(TEMPLATE_TEXT, <<"
 {% if A %}
-  A
-  {% endif %}
+ A
+ {% endif %}
 
-    {% if B %}
-      B
-      {% endif %}
-        C
-        ">>).
+  {% if B %}
+   B
+   {% endif %}
+    C
+    ">>).
 
 a() ->
-              ?TEMPLATE_TEXT.
+           ?TEMPLATE_TEXT.

--- a/test/before/tabs.erl
+++ b/test/before/tabs.erl
@@ -19,6 +19,27 @@ b/1
 
 %% API
 
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+
+-spec release(kz_term:ne_binaries()) -> ret().
+release(Nums) ->
+release(Nums, knm_number_options:default()).
+
+-spec release(kz_term:ne_binaries(), knm_number_options:options()) -> ret().
+release(Nums, Options) ->
+ret(pipe(do_get_pn(Nums, Options)
+,[fun try_release/1
+,fun knm_number:new/1
+,fun knm_providers:delete/1
+,fun unwind_maybe_disconnect/1
+,fun save_phone_numbers/1
+])).
+
+
+
 t(ABS) -> erlang:abs(
 ABS
 ).


### PR DESCRIPTION
Note: https://github.com/erlang/otp/pull/1681 changed how a few things are indented. See https://github.com/dgud/otp/tree/13f1dec0220d44e5178feb52cf076dbdebaa23a0/lib/tools/test/emacs_SUITE_data